### PR TITLE
インストール時にsolrのディレクトリの所有者を指定

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ docker cp $id:/enju_leaf/db/migrate .
 docker cp $id:/enju_leaf/private/system .
 docker rm -v $id
 
-sudo chown 991:991 -R ./system ./migrate # .env.production の UID と GID の値に合わせる
+mkdir solr
+sudo chown 991:991 -R ./system ./migrate ./solr # .env.production の UID と GID の値に合わせる
 ```
 
 ### データベースの初期設定

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,13 @@ sudo docker cp $id:/enju_leaf/db/migrate .
 docker cp $id:/enju_leaf/private/system .
 docker rm -v $id
 
-sudo chown 991:991 -R ./system ./migrate
+mkdir solr
+sudo chown 991:991 -R ./system ./migrate ./solr
 
 export DB_USER=enju_leaf DB_NAME=enju_leaf_production DB_PASS=admin
 export POSTGRES_PASSWORD=admin
-sleep 10 \
+docker-compose up -d db \
+  && sleep 10 \
   && docker-compose exec -u postgres db sh -c "echo create user ${DB_USER} with password \'${DB_PASS}\' createdb\; | psql -f -" \
   && docker-compose exec -u postgres db createdb -U ${DB_USER} ${DB_NAME}
 export POSTGRES_PASSWORD=


### PR DESCRIPTION
インストール時に`docker-compose run --rm web bundle exec rake enju_leaf:setup`を実行すると以下のエラーが発生しています

> RSolr::Error::Http: RSolr::Error::Http - 500 Internal Server Error
> Error:     {msg=SolrCore &apos;default&apos; is not available due to init failure: /enju_leaf/solr/default/data/index/write.lock,trace=org.apache.solr.common.SolrException: SolrCore &apos;default&apos; is not available due to init failure: /enju_leaf/solr/default/data/index/write.lock
>	at org.apache.solr.core.CoreContainer.getCore(CoreContainer.java:974)

これに対処するためsolrディレクトリの所有者を991:991に変更します。
あわせてREADMEをアップデートしました。