### PR TITLE
GitHub Actionsのワークフローを追加

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,30 @@
+name: Publish Docker image
+on:
+  - push
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: docker.pkg.github.com/${{ github.repository }}/enju_leaf
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Docker Hub の Free プランで Automated builds ができなくなっていたので、GitHub Package Registry でイメージを公開するためのワークフローを追加しました。

push イベントで実行する設定のため、ブランチやタグの push 時に `master`, `v1.3.3`, `latest` 等のタグ名で docker push されます。
（参考: https://github.com/docker/metadata-action#basic ）